### PR TITLE
chore: add .nvmrc (lts/dubnium)

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/dubnium


### PR DESCRIPTION
Dodaje `.nvmrc` z `lts/dubnium`.

dopasowane do engines '>=10' (Node 10).

Dzięki temu `nvm use` automatycznie dobiera właściwą linię Node dla repo.